### PR TITLE
Fix issues for Jinja user study, primarily around login/signup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "python.analysis.enableJinjaSupport": true,
     "python.formatting.provider": "none",
     "editor.formatOnSave": true,
     "python.languageServer": "Pylance",

--- a/frontend/templates/login.html
+++ b/frontend/templates/login.html
@@ -3,19 +3,6 @@
 Petgram
 {% endblock %}
 {% block content %}
-{% if request.query_params.error == "invalid_credentials" %}
-<p>Invalid username or password.</p>
-{% elif request.query_params.error == "database_error" %}
-<p> Failed to connect to database.</p>
-{% elif request.query_params.error == "not_found" %}
-<p> User not found.</p>
-{% elif request.query_params.error == "conflict" %}
-<p> User already exists.</p>
-{% elif request.query_params.error == "bad_request" %}
-<p> Failed to sign up. </p>
-{% elif request.query_params.error == "unprocessable_entity" %}
-<p> Passwords don't match. </p>
-{% endif %}
 <div id="app">
     <form method="POST" action="/auth/token/">
         🐾 Username: <input type="text" name="username"></input>

--- a/frontend/templates/login.html
+++ b/frontend/templates/login.html
@@ -3,8 +3,13 @@
 Petgram
 {% endblock %}
 {% block content %}
+{% if error == "InvalidUserNameOrPassword" %}
+<p> Invalid username or password.</p>
+{% elif error == "DatabaseError" %}
+<p> Failed to connect to database.</p>
+{% endif %}
 <div id="app">
-    <form method="POST" action="/auth/token/">
+    <form method="POST" action="/auth/">
         🐾 Username: <input type="text" name="username"></input>
         🔐 Password: <input type="password" name="password"></input>
         <button type="submit">Log in</button>

--- a/frontend/templates/signup.html
+++ b/frontend/templates/signup.html
@@ -3,6 +3,13 @@
 Petgram
 {% endblock %}
 {% block content %}
+{% if error == "UserAlreadyExists" %}
+<p> User already exists.</p>
+{% elif error == "UserCreationFailed" %}
+<p> Failed to sign up. </p>
+{% elif error == "PasswordsDoNotMatch" %}
+<p> Passwords don't match. </p>
+{% endif %}
 <div id="app">
     <form method="POST" action="/create">
         🐾 Username: <input type="text" name="username"></input>


### PR DESCRIPTION
1. Reworked the error handling in `create_user` and `login_auth` so when an error occurs the signup/login template is redisplayed with the error at the top (above the data entry form). If user creation succeeds, you're sent to the login page.
2. Added `"python.analysis.enableJinjaSupport": true` to the `.vscode/settings.json` so Jinja support is enabled when you're not using a devcontainer.
3. Small tweak to `display_feed` so `username` is seen as a `str` within the template (ex. if you hover over `{{username}}`) rather than as a `Column` object.

The signup/login changes work but are perhaps not a good example of production-ready auth code. I'm happy to take another shot at this if you don't like anything in there.